### PR TITLE
allow uppercase characters in searchterm bar

### DIFF
--- a/client/components/products/SearchBar.js
+++ b/client/components/products/SearchBar.js
@@ -18,7 +18,7 @@ class SearchBar extends React.Component {
   }
 
   handleChange(event) {
-    this.setState({searchTerm: event.target.value.toLowerCase()});
+    this.setState({searchTerm: event.target.value});
   }
 
   handleSearch(event) {


### PR DESCRIPTION
Users can now type uppercase and lowercase letters in the search bar.